### PR TITLE
Fix gym version (specific commit)

### DIFF
--- a/unit2/unit2.ipynb
+++ b/unit2/unit2.ipynb
@@ -201,7 +201,7 @@
       "cell_type": "code",
       "source": [
         "%%capture\n",
-        "!pip install git+https://github.com/openai/gym.git # We install gym using git since Taxi-v3 \"rgb_array version\" is not on PyPi release\n",
+        "!pip install git+https://github.com/openai/gym.git@a37b956d57bdb024ccd8fef5446ba159e32d4626 # We install gym using git since Taxi-v3 \"rgb_array version\" is not on PyPi release\n",
         "!pip install pygame\n",
         "!pip install numpy\n",
         "\n",


### PR DESCRIPTION
As I mentioned on Discord, the current notebook directly installs from gym's master branch, which is risky because of (a) possible bugs between releases, and (b) deprecated/removed features in the future.

This PR fixes the gym installation to a specific commit (the most recent merged one as of writing this message) so that the class will continue to work the same way it does now, even a year from now. Unless a meteor strikes the GitHub datacenter or something.

I also suggest updating this again once we release 0.24, which will happen hopefully soon, and just set it to that release.

ETA: this only applies to the second week's notebook, as SB3 currently requires a slightly outdated version of gym