### PR TITLE
(Again) Update gym in Unit 2

### DIFF
--- a/unit2/unit2.ipynb
+++ b/unit2/unit2.ipynb
@@ -201,7 +201,7 @@
       "cell_type": "code",
       "source": [
         "%%capture\n",
-        "!pip install git+https://github.com/openai/gym.git@a37b956d57bdb024ccd8fef5446ba159e32d4626 # We install gym using git since Taxi-v3 \"rgb_array version\" is not on PyPi release\n",
+        "!pip install gym==0.24 # We install the newest gym version for the Taxi-v3 \"rgb_array version\"\n",
         "!pip install pygame\n",
         "!pip install numpy\n",
         "\n",


### PR DESCRIPTION
Follow-up to #38, this time it's an actual release! We released gym 0.24, so it's better to peg the setup to it, rather than the commit I specified last time. 

The changes introduced in the meantime (that could be relevant for people here) include a support for the new open-source MuJoCo envs (!), and minimal support for python 3.6 if someone *really* needs to use it (though it's discouraged). There's also a whole slew of other stuff in the release overall, which you can check in the [changelog](https://github.com/openai/gym/releases/tag/0.24.0)