### PR TITLE
Fixing Unit 1 Fig reference

### DIFF
--- a/units/en/unit1/exp-exp-tradeoff.mdx
+++ b/units/en/unit1/exp-exp-tradeoff.mdx
@@ -26,7 +26,7 @@ If it’s still confusing, **think of a real problem: the choice of picking a re
 
 <figure>
 <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit1/exp_2.jpg" alt="Exploration">
-<figcaption>Source: <a href="[http://rail.eecs.berkeley.edu/deeprlcourse-fa17/f17docs/lecture_13_exploration.pdf](http://rail.eecs.berkeley.edu/deeprlcourse-fa17/f17docs/lecture_13_exploration.pdf)"> Berkley AI Course</a>
+<figcaption>Source: <a href="https://inst.eecs.berkeley.edu/~cs188/sp20/assets/lecture/lec15_6up.pdf"> Berkley AI Course</a>
 </figcaption>
 </figure>
 


### PR DESCRIPTION
Current reference to the exploration/exploitation ref is pointing to the wrong PDF file of the wrong Berkeley course (CS 285 "Deep Reinforcement Learning" doesn't have this illustration, it comes from the more general CS 188 "Artificial Intelligence"). And the URL format was wrong too.