### PR TITLE
Use image without slide number overlay

### DIFF
--- a/units/en/unit3/deep-q-algorithm.mdx
+++ b/units/en/unit3/deep-q-algorithm.mdx
@@ -49,7 +49,7 @@ Experience replay also has other benefits. By randomly sampling the experiences,
 
 In the Deep Q-Learning pseudocode, we **initialize a replay memory buffer D from capacity N** (N is a hyperparameter that you can define). We then store experiences in the memory and sample a batch of experiences to feed the Deep Q-Network during the training phase.
 
-<img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit4/experience-replay-pseudocode.jpg" alt="Experience Replay Pseudocode"/>
+<img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit4/experience-replay.jpg" alt="Experience Replay Pseudocode"/>
 
 ## Fixed Q-Target to stabilize the training [[fixed-q]]
 


### PR DESCRIPTION
In this [section](https://huggingface.co/deep-rl-course/unit3/deep-q-algorithm#exp-replay) same image is used [here](https://huggingface.co/deep-rl-course/unit3/deep-q-algorithm#exp-replay:~:text=Experience%20replay%20helps%20using%20the%20experiences%20of%20the%20training%20more%20efficiently.%20We%20use%20a%20replay%20buffer%20that%20saves%20experience%20samples%C2%A0that%20we%20can%20reuse%20during%20the%20training.) and [here](https://huggingface.co/deep-rl-course/unit3/deep-q-algorithm#exp-replay:~:text=In%20the%20Deep%20Q%2DLearning%20pseudocode%2C%20we%20initialize%20a%20replay%20memory%20buffer%20D%20from%20capacity%20N%20(N%20is%20a%20hyperparameter%20that%20you%20can%20define).%20We%20then%20store%20experiences%20in%20the%20memory%20and%20sample%20a%20batch%20of%20experiences%20to%20feed%20the%20Deep%20Q%2DNetwork%20during%20the%20training%20phase.), but in the latter it appears the slide number overlay:

![image](https://user-images.githubusercontent.com/61120139/209557769-d9f5ea7c-b2ec-4b77-8950-7422cf59084f.png)

As both images have the same content, I replaced the second one not to have the overlay

Note: [experience-replay-pseudocode.jpg](https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit4/experience-replay-pseudocode.jpg) appears to be a dupe of [experience-replay.jpg](https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit4/experience-replay.jpg)