### PR TITLE
Unit6: Fixed env name in one of the code blocks

### DIFF
--- a/units/en/unit6/hands-on.mdx
+++ b/units/en/unit6/hands-on.mdx
@@ -350,7 +350,7 @@ In `PandaReachDense-v2`, the robotic arm must place its end-effector at a target
 ```python
 import gym
 
-env_id = "PandaPushDense-v2"
+env_id = "PandaReachDense-v2"
 
 # Create the env
 env = gym.make(env_id)


### PR DESCRIPTION
Somehow wrong env name got into one of the code blocks, and I've been solving a different env for a while because copied the name from this unlucky location 😄 
```
env_id = "PandaPushDense-v2"
```
needs to be
```
env_id = "PandaReachDense-v2"
```
I'd think.