### PR TITLE
Units 1 and 6: Fix for installing notebook dependencies

### DIFF
--- a/notebooks/unit1/unit1.ipynb
+++ b/notebooks/unit1/unit1.ipynb
@@ -232,6 +232,18 @@
     },
     {
       "cell_type": "code",
+      "source": [
+        "# Install the specific setuptools version required to install the dependencies\n",
+        "!pip install setuptools==65.5.0"
+      ],
+      "metadata": {
+        "id": "eUamMNshb6ee"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
       "metadata": {
         "id": "9XaULfDZDvrC"

--- a/notebooks/unit6/unit6.ipynb
+++ b/notebooks/unit6/unit6.ipynb
@@ -248,6 +248,18 @@
     },
     {
       "cell_type": "code",
+      "source": [
+        "# Install the specific setuptools version required to install the dependencies\n",
+        "!pip install setuptools==65.5.0"
+      ],
+      "metadata": {
+        "id": "eUamMNshb6ee"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
       "execution_count": null,
       "metadata": {
         "id": "2yZRi_0bQGPM"


### PR DESCRIPTION
Fixes https://github.com/huggingface/deep-rl-class/issues/251, https://github.com/huggingface/deep-rl-class/issues/253, and https://github.com/huggingface/deep-rl-class/issues/255.

Currently, this notebook can't be run because of an error while installing the dependencies.

The error comes from trying to install the `stable-baselines3` package. They are aware of this bug and working on it for the next version. Their current workaround is to use the `65.5.0` version of `setuptools` by running `pip install setuptools==65.5.0`. For more information, see https://github.com/DLR-RM/stable-baselines3/issues/1324.

Adding the line `setuptools==65.5.0` at the top of the [`requirements-unit6.txt`](https://github.com/huggingface/deep-rl-class/blob/main/notebooks/unit6/requirements-unit6.txt) file doesn't solve the problem since `pip` doesn't have a way to install packages in order (see https://github.com/pypa/pip/issues/2362).

Therefore, the solution is to add a new code cell to the notebook to run `pip install setuptools==65.5.0` before installing [`requirements-unit6.txt`](https://github.com/huggingface/deep-rl-class/blob/main/notebooks/unit6/requirements-unit6.txt).