### PR TITLE
Fix setuptools pip install command

### DIFF
--- a/notebooks/unit3/unit3.ipynb
+++ b/notebooks/unit3/unit3.ipynb
@@ -289,7 +289,7 @@
       },
       "outputs": [],
       "source": [
-        "pip install setuptools==65.5.0\n",
+        "!pip install setuptools==65.5.0\n",
         "!pip install -r requirements.txt\n",
         "# Since colab uses Python 3.9 we need to add this installation\n",
         "!pip install gym[atari,accept-rom-license]==0.21.0"


### PR DESCRIPTION
The cell fails due to missing `!` when trying to install `setuptools`, so this PR adds it.