### PR TITLE
Fixed RL-baselines3-zoo version on unit 3 notebook

### DIFF
--- a/notebooks/unit3/unit3.ipynb
+++ b/notebooks/unit3/unit3.ipynb
@@ -278,7 +278,8 @@
       },
       "outputs": [],
       "source": [
-        "%cd /content/rl-baselines3-zoo/"
+        "%cd /content/rl-baselines3-zoo/ \n",
+        "!git checkout v1.8.0"
       ]
     },
     {


### PR DESCRIPTION
Just added a checkout to the v1.8.0 tag of the cloned repo to keep the notebook working. With the current commit, the train.py script & enjoy.py script doesn't work.