### PR TITLE
docs: update PixelCopter action space notes

### DIFF
--- a/units/en/unit4/hands-on.mdx
+++ b/units/en/unit4/hands-on.mdx
@@ -888,8 +888,8 @@ The observation space (7) 👀:
 - next blocks bottom y location
 
 The action space(2) 🎮:
-- Up
-- Down
+- Up (press accelerator)
+- Do nothing (don't press accelerator)
 
 The reward function 💰:
 - For each vertical block it passes, it gains a positive reward of +1. Each time a terminal state is reached it receives a negative reward of -1.


### PR DESCRIPTION
Update unit 4 notes on PixelCopter action space from [up, down] to [up, nothing] to match PixelCopter single active action (pressing accelerator).

closes #315 