### PR TITLE
fix for rose/red color tiles naming (#317)

### DIFF
--- a/units/en/unit4/advantages-disadvantages.mdx
+++ b/units/en/unit4/advantages-disadvantages.mdx
@@ -28,7 +28,7 @@ Let's take an example: we have an intelligent vacuum cleaner whose goal is to su
 
 Our vacuum cleaner can only perceive where the walls are.
 
-The problem is that the **two rose cases are aliased states because the agent perceives an upper and lower wall for each**.
+The problem is that the **two red (colored) states are aliased states because the agent perceives an upper and lower wall for each**.
 
 <figure class="image table text-center m-0 w-full">
   <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit6/hamster2.jpg" alt="Hamster 1"/>


### PR DESCRIPTION
Rename rose to red (coloured) state, since red is the preferred usage (as elsewhere in the document: line 37),