### PR TITLE
fix: (unit-7 hands on) executable filepath typo

### DIFF
--- a/units/en/unit7/hands-on.mdx
+++ b/units/en/unit7/hands-on.mdx
@@ -88,7 +88,7 @@ Finally, you need to install git-lfs: https://git-lfs.com/
 
 Now that it’s installed, we need to add the environment training executable. Based on your operating system you need to download one of them, unzip it and place it in a new folder inside `ml-agents` that you call `training-envs-executables`
 
-At the end your executable should be in `mlagents/training-envs-executables/SoccerTwos`
+At the end your executable should be in `ml-agents/training-envs-executables/SoccerTwos`
 
 Windows: Download [this executable](https://drive.google.com/file/d/1sqFxbEdTMubjVktnV4C6ICjp89wLhUcP/view?usp=sharing)
 


### PR DESCRIPTION
Executable file should be in ./ml-agents, docs have typo.