### PR TITLE
Fix Typos in Unit 1: The Reinforcement Learning Framework

### DIFF
--- a/units/en/unit1/rl-framework.mdx
+++ b/units/en/unit1/rl-framework.mdx
@@ -44,7 +44,7 @@ Observations/States are the **information our agent gets from the environment.*
 
 There is a differentiation to make between *observation* and *state*, however:
 
-- *State s*: is **a complete description of the state of the world** (there is no hidden information). In a fully observed environment.
+- *State* is **a complete description of the state of the world** (there is no hidden information).
 
 
 <figure>
@@ -54,14 +54,12 @@ There is a differentiation to make between *observation* and *state*, however:
 
 In a chess game, we have access to the whole board information, so we receive a state from the environment. In other words, the environment is fully observed.
 
-- *Observation o*: is a **partial description of the state.** In a partially observed environment.
+- *Observation* is a **partial description of the state.**
 
 <figure>
 <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit1/mario.jpg" alt="Mario">
 <figcaption>In Super Mario Bros, we only see the part of the level close to the player, so we receive an observation.</figcaption>
 </figure>
-
-In Super Mario Bros, we only see the part of the level close to the player, so we receive an observation.
 
 In Super Mario Bros, we are in a partially observed environment. We receive an observation **since we only see a part of the level.**
 
@@ -69,7 +67,6 @@ In Super Mario Bros, we are in a partially observed environment. We receive an 
 In this course, we use the term "state" to denote both state and observation, but we will make the distinction in implementations.
 </Tip>
 
-To recap:
 <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit1/obs_space_recap.jpg" alt="Obs space recap" width="100%">
 
 
@@ -97,7 +94,6 @@ In Super Mario Bros, we have a finite set of actions since we have only 4 direct
 </figcaption>
 </figure>
 
-To recap:
 <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit1/action_space.jpg" alt="Action space recap" width="100%">
 
 Taking this information into consideration is crucial because it will **have importance when choosing the RL algorithm in the future.**

--- a/units/en/unit1/tasks.mdx
+++ b/units/en/unit1/tasks.mdx
@@ -15,13 +15,12 @@ For instance, think about Super Mario Bros: an episode begin at the launch of a 
 </figure>
 
 
-## Continuing tasks [[continuing-tasks]]
+## Continuous task [[continuing-tasks]]
 
 These are tasks that continue forever (**no terminal state**). In this case, the agent must **learn how to choose the best actions and simultaneously interact with the environment.**
 
-For instance, an agent that does automated stock trading. For this task, there is no starting point and terminal state. **The agent keeps running until we decide to stop it.**
+For instance, an agent that does automated stock trading has no starting point nor terminal state. **The agent keeps running until we decide to stop it.**
 
 <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit1/stock.jpg" alt="Stock Market" width="100%">
 
-To recap:
 <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit1/tasks.jpg" alt="Tasks recap" width="100%">


### PR DESCRIPTION
Purpose:
This pull request fixes small typos in the Unit 1: The Reinforcement Learning Framework page. While not necessary, these changes add to reading comprehension by eliminating distracting errors.

List of changes:
- Removes abbreviated letters from 'state' and 'observation'. If these abbreviations need to be kept, they should be placed in parenthesis to indicate that they are not adding new information but rather summarizing old information, like *State* (s). However, since these single letters will likely only be used in context of the observation/states space, a reader should be able to figure it out themselves. 
- Removes colon after 'state' and 'observation' definition. Because the noun being defined is a part of the sentence, it should remain in italics while removing the colon to place it into the sentence. 
- Removes repeating Mario Bros example statement. This deletes the slightly less explained example. 
- Removes the 'To recap' lines because the picture in itself is a recap, rendering the words unnecessary.