### PR TITLE
Update requirements-unit1.txt

### DIFF
--- a/notebooks/unit1/requirements-unit1.txt
+++ b/notebooks/unit1/requirements-unit1.txt
@@ -1,3 +1,4 @@
 stable-baselines3==2.0.0a5
+swig
 gymnasium[box2d]
 huggingface_sb3


### PR DESCRIPTION
Box2d has a dependency on Swig, which is not auto installed. 

https://github.com/openai/gym/issues/3143#issuecomment-1569011274

https://stackoverflow.com/questions/76222239/pip-install-gymnasiumbox2d-not-working-on-google-colab

