### PR TITLE
Unit 2 Correct FrozenLake's observation space

### DIFF
--- a/notebooks/unit2/unit2.ipynb
+++ b/notebooks/unit2/unit2.ipynb
@@ -429,7 +429,7 @@
         "id": "2MXc15qFE0M9"
       },
       "source": [
-        "We see with `Observation Space Shape Discrete(16)` that the observation is an integer representing the **agent’s current position as current_row * nrows + current_col (where both the row and col start at 0)**.\n",
+        "We see with `Observation Space Shape Discrete(16)` that the observation is an integer representing the **agent’s current position as current_row * ncols + current_col (where both the row and col start at 0)**.\n",
         "\n",
         "For example, the goal position in the 4x4 map can be calculated as follows: 3 * 4 + 3 = 15. The number of possible observations is dependent on the size of the map. **For example, the 4x4 map has 16 possible observations.**\n",
         "\n",

--- a/units/en/unit2/hands-on.mdx
+++ b/units/en/unit2/hands-on.mdx
@@ -247,7 +247,7 @@ print("Observation Space", env.observation_space)
 print("Sample observation", env.observation_space.sample())  # Get a random observation
 ```
 
-We see with `Observation Space Shape Discrete(16)` that the observation is an integer representing the **agent’s current position as current_row * nrows + current_col (where both the row and col start at 0)**.
+We see with `Observation Space Shape Discrete(16)` that the observation is an integer representing the **agent’s current position as current_row * ncols + current_col (where both the row and col start at 0)**.
 
 For example, the goal position in the 4x4 map can be calculated as follows: 3 * 4 + 3 = 15. The number of possible observations is dependent on the size of the map. **For example, the 4x4 map has 16 possible observations.**
 


### PR DESCRIPTION
There was an error in Farama's documentation about the agent's position / the observation space of FrozenLake's environment. The issue in Farama's documentation is [described here](https://github.com/Farama-Foundation/Gymnasium/issues/692) and corrected [in this PR](https://github.com/Farama-Foundation/Gymnasium/pull/695).

In one word, the agent's position was described as:
> current_row * nrows + current_col (where both the row and col start at 0)

It actually should be:
> current_row * **ncols** + current_col (where both the row and col start at 0)

As this formula remains correct for generalization to non-square matrices.


The present PR brings the same correction to HF's Unit 2.