### PR TITLE
Update Unit 7 hands-on.mdx

### DIFF
--- a/units/en/unit7/hands-on.mdx
+++ b/units/en/unit7/hands-on.mdx
@@ -84,6 +84,12 @@ We also need to install pytorch with:
 pip install torch
 ```
 
+As well as the following dependency:
+
+```bash
+pip install onnx==1.12.0
+```
+
 Finally, you need to install git-lfs: https://git-lfs.com/
 
 Now that it’s installed, we need to add the environment training executable. Based on your operating system you need to download one of them, unzip it and place it in a new folder inside `ml-agents` that you call `training-envs-executables`


### PR DESCRIPTION
onnx v1.12.0 is needed because of protobuf v3.19.6 is used for the setup, later versions of onnx is not compatible.