### PR TITLE
Unit3: Removed order of magnitude for timesteps and a duplicated ffmpeg installation

### DIFF
--- a/notebooks/unit3/unit3.ipynb
+++ b/notebooks/unit3/unit3.ipynb
@@ -277,7 +277,6 @@
       "source": [
         "%%capture\n",
         "!apt install python-opengl\n",
-        "!apt install ffmpeg\n",
         "!apt install xvfb\n",
         "!pip3 install pyvirtualdisplay"
       ]
@@ -317,7 +316,7 @@
         "    - stable_baselines3.common.atari_wrappers.AtariWrapper\n",
         "  frame_stack: 4\n",
         "  policy: 'CnnPolicy'\n",
-        "  n_timesteps: !!float 1e7\n",
+        "  n_timesteps: !!float 1e6\n",
         "  buffer_size: 100000\n",
         "  learning_rate: !!float 1e-4\n",
         "  batch_size: 32\n",


### PR DESCRIPTION
1. With `n_timesteps: !!float 1e7` it takes a whole day to train a model. As it was suggested [in the discord channel](https://discord.com/channels/879548962464493619/971379033642266654/1113757769049321472) change number of timesteps to 1e6
2. `ffmpeg` is being installed twice. Removed 2nd attempt.