### PR TITLE
Removed unnecessary pip install's

### DIFF
--- a/units/en/unit7/hands-on.mdx
+++ b/units/en/unit7/hands-on.mdx
@@ -78,18 +78,6 @@ pip install -e ./ml-agents-envs
 pip install -e ./ml-agents
 ```
 
-We also need to install pytorch with:
-
-```bash
-pip install torch
-```
-
-As well as the following dependency:
-
-```bash
-pip install onnx==1.12.0
-```
-
 Finally, you need to install git-lfs: https://git-lfs.com/
 
 Now that it’s installed, we need to add the environment training executable. Based on your operating system you need to download one of them, unzip it and place it in a new folder inside `ml-agents` that you call `training-envs-executables`


### PR DESCRIPTION
Reason: both pytorch and onxx==1.12.0 are installed in scope of `pip install -e ./ml-agents` (line 78)