### PR TITLE
Update train.mdx : this commit fixes #443

### DIFF
--- a/units/en/unitbonus1/train.mdx
+++ b/units/en/unitbonus1/train.mdx
@@ -203,7 +203,7 @@ With ML Agents, we run a training script. We define four parameters:
 
 1. `mlagents-learn <config>`: the path where the hyperparameter config file is.
 2. `--env`: where the environment executable is.
-3. `--run_id`: the name you want to give to your training run id.
+3. `--run-id`: the name you want to give to your training run id.
 4. `--no-graphics`: to not launch the visualization during the training.
 
 Train the model and use the `--resume` flag to continue training in case of interruption.


### PR DESCRIPTION
ML Agents parameter --run-id : misspelled with underscore instead of hypen