### PR TITLE
Changes to obs space descriptions in unit6.ipynb

### DIFF
--- a/notebooks/unit6/unit6.ipynb
+++ b/notebooks/unit6/unit6.ipynb
@@ -363,8 +363,8 @@
       "cell_type": "markdown",
       "source": [
         "The observation space **is a dictionary with 3 different elements**:\n",
-        "- `achieved_goal`: (x,y,z) position of the goal.\n",
-        "- `desired_goal`: (x,y,z) distance between the goal position and the current object position.\n",
+        "- `achieved_goal`: (x,y,z) the current position of the end-effector.\n",
+        "- `desired_goal`: (x,y,z) the target position for the end-effector.\n",
         "- `observation`: position (x,y,z) and velocity of the end-effector (vx, vy, vz).\n",
         "\n",
         "Given it's a dictionary as observation, **we will need to use a MultiInputPolicy policy instead of MlpPolicy**."


### PR DESCRIPTION
This PR features some proposed changes to the description of the observation space.

However, please verify the validity first since I'm not very familiar with this env.

My current understanding after taking a look at (https://panda-gym.readthedocs.io/en/latest/custom/custom_task.html) and (https://github.com/qgallouedec/panda-gym/blob/master/panda_gym/envs/tasks/reach.py#L47-L48) is that the `desired_goal` is likely the target position for the end-effector (also the position of the target object used to indicate the goal) which is randomly sampled on restart, while the [achieved_goal](https://github.com/qgallouedec/panda-gym/blob/51fb901db6968cb8a78ebb11070d313566700d38/panda_gym/envs/tasks/reach.py#L43C8-L43C8) is the current position of the end-effector, with reward being the `-(distance between the two)` in the dense version.

The success condition is then whether the difference between `achieved` and `desired` goals is less than the threshold.