### PR TITLE
bonus-unit1: using gdown of version 4.5.4 to download from google drive instead of wget

### DIFF
--- a/notebooks/bonus-unit1/bonus-unit1.ipynb
+++ b/notebooks/bonus-unit1/bonus-unit1.ipynb
@@ -220,7 +220,7 @@
       "cell_type": "code",
       "source": [
         "!pip install --upgrade --no-cache-dir gdown==4.5.4\n",
-        "gdown 1zv3M95ZJTWHUVOWT6ckq_cm98nft8gdF -O ./trained-envs-executables/linux/Huggy.zip"
+        "!gdown 1zv3M95ZJTWHUVOWT6ckq_cm98nft8gdF -O ./trained-envs-executables/linux/Huggy.zip"
       ],
       "metadata": {
         "id": "EB-G-80GsxYN"


### PR DESCRIPTION
The file cannot be downloaded from google drive using wget like this:

```
!wget --load-cookies /tmp/cookies.txt \"https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate 'https://docs.google.com/uc?export=download&id=1zv3M95ZJTWHUVOWT6ckq_cm98nft8gdF' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\\1\\n/p')&id=1zv3M95ZJTWHUVOWT6ckq_cm98nft8gdF\" -O ./trained-envs-executables/linux/Huggy.zip && rm -rf /tmp/cookies.txt
```

using gdown==4.5.4 instead is working