### PR TITLE
Create datapredict.mdx

### DIFF
--- a/units/en/unitbonus3/datapredict.mdx
+++ b/units/en/unitbonus3/datapredict.mdx
@@ -1,0 +1,7 @@
+# An Introduction To DataPredict
+
+DataPredict is a machine, deep and reinforcement learning library written in Lua, but focuses on the Roblox Studio environment.
+
+It contains more than 35 models, 18 of which focuses on reinforcement learning. Its modular design allows developers to flexibly design their agents and its environments.
+
+You can have a look at the tutorials and the documentation for DataPredict [here](https://aqwamcreates.github.io/DataPredict/)

--- a/units/en/unitbonus3/datapredict.mdx
+++ b/units/en/unitbonus3/datapredict.mdx
@@ -4,4 +4,6 @@ DataPredict is a machine, deep and reinforcement learning library written in Lua
 
 It contains more than 35 models, 18 of which focuses on reinforcement learning. Its modular design allows developers to flexibly design their agents and its environments.
 
+<img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/unit12/datapredict.png" alt="Datapredict"/>
+
 You can have a look at the tutorials and the documentation for DataPredict [here](https://aqwamcreates.github.io/DataPredict/)


### PR DESCRIPTION
There's another reinforcement library that I want to add into the rl-course, named DataPredict, which is for Roblox, but is not created by Roblox. Not sure if this place is appropriate for that library since that library focuses on machine learning on general.

Also, feel free to add more information. I couldn't upload the image I wanted to add to this file. 

![home-card-3](https://github.com/huggingface/deep-rl-class/assets/67371914/700a05b0-5a19-4663-b2fa-e88ff3e00aa6)

This is the image i want to add from [datapredict.online](https://datapredict.online).