### PR TITLE
Fixed typeset in (optional) policy gradient theorem

### DIFF
--- a/units/en/unit4/pg-theorem.mdx
+++ b/units/en/unit4/pg-theorem.mdx
@@ -28,9 +28,9 @@ We then multiply every term in the sum by \\(\frac{P(\tau;\theta)}{P(\tau;\theta
 \\( = \sum_{\tau} \frac{P(\tau;\theta)}{P(\tau;\theta)}\nabla_\theta P(\tau;\theta)R(\tau) \\)
 
 
-We can simplify further this since \\( \frac{P(\tau;\theta)}{P(\tau;\theta)}\nabla_\theta P(\tau;\theta)\\). 
+We can simplify further this since \\( \frac{P(\tau;\theta)}{P(\tau;\theta)}\nabla_\theta P(\tau;\theta) =  P(\tau;\theta)\frac{\nabla_\theta P(\tau;\theta)}{P(\tau;\theta)}  \\). 
 
-Thus we can rewrite the sum as \\( =  P(\tau;\theta)\frac{\nabla_\theta P(\tau;\theta)}{P(\tau;\theta)}  \\)
+Thus we can rewrite the sum as
 
 \\( P(\tau;\theta)\frac{\nabla_\theta P(\tau;\theta)}{P(\tau;\theta)}= \sum_{\tau} P(\tau;\theta) \frac{\nabla_\theta P(\tau;\theta)}{P(\tau;\theta)}R(\tau) \\)
 


### PR DESCRIPTION
Hi,

I am currently following HuggingFace's Deep RL course. The course is great so far, but I can't help but notice an error in the math typeset in optional chapter about the policy gradient theorem. I have fixed that in this pull request.

However, I believe we can have better typeset on the tutorial just like in calculus textbook, but I need to understand the typeset system you are using in the tutorials to work further, especially how does it show mathematical equations. I have an extensive experience in typesetting with LaTeX, so I think I can help if the syntax closely resembles that language.

Please let me know if you would like me to help with the typeset. I would _love_ to see a nice, textbook-like typeset in this optional chapter.

Thanks!
Vichayanun