### PR TITLE
[FIX] Wrong Huggy path when pushing to Hub

### DIFF
--- a/notebooks/bonus-unit1/bonus-unit1.ipynb
+++ b/notebooks/bonus-unit1/bonus-unit1.ipynb
@@ -529,7 +529,7 @@
       },
       "outputs": [],
       "source": [
-        "!mlagents-push-to-hf --run-id=\"HuggyTraining\" --local-dir=\"./results/Huggy\" --repo-id=\"ThomasSimonini/ppo-Huggy\" --commit-message=\"Huggy\""
+        "!mlagents-push-to-hf --run-id=\"HuggyTraining\" --local-dir=\"./results/Huggy2\" --repo-id=\"ThomasSimonini/ppo-Huggy\" --commit-message=\"Huggy\""
       ]
     },
     {

--- a/notebooks/bonus-unit1/bonus_unit1.ipynb
+++ b/notebooks/bonus-unit1/bonus_unit1.ipynb
@@ -529,7 +529,7 @@
       },
       "outputs": [],
       "source": [
-        "!mlagents-push-to-hf --run-id=\"HuggyTraining\" --local-dir=\"./results/Huggy\" --repo-id=\"ThomasSimonini/ppo-Huggy\" --commit-message=\"Huggy\""
+        "!mlagents-push-to-hf --run-id=\"HuggyTraining\" --local-dir=\"./results/Huggy2\" --repo-id=\"ThomasSimonini/ppo-Huggy\" --commit-message=\"Huggy\""
       ]
     },
     {


### PR DESCRIPTION
Current version of pushing Huggy to Hub:

```
!mlagents-push-to-hf --run-id="HuggyTraining" --local-dir="./results/Huggy2" --repo-id="Laz4rz/hf-huggy-1-bonus" --commit-message="add Huggy agent"
```

yields:

```
[INFO] This function will create a model card and upload your HuggyTraining into HuggingFace Hub. This is a work in progress: If you encounter a bug, please send open an issue
Traceback (most recent call last):
  File "/usr/local/bin/mlagents-push-to-hf", line 33, in <module>
    sys.exit(load_entry_point('mlagents', 'console_scripts', 'mlagents-push-to-hf')())
  File "/content/ml-agents/ml-agents/mlagents/utils/push_to_hf.py", line 205, in main
    package_to_hub(
  File "/content/ml-agents/ml-agents/mlagents/utils/push_to_hf.py", line 159, in package_to_hub
    _generate_config(local_path, configfile_name)
  File "/content/ml-agents/ml-agents/mlagents/utils/push_to_hf.py", line 29, in _generate_config
    with open(os.path.join(local_dir, configfile_name)) as yaml_in:
FileNotFoundError: [Errno 2] No such file or directory: 'results/Huggy/configuration.yaml'
```

This only needs the path to be changed from "Huggy" to "Huggy2".