### PR TITLE
[UNIT 8 part 2] Fix for `sample-factory` dependencies issue. 

### DIFF
--- a/notebooks/unit8/unit8_part2.ipynb
+++ b/notebooks/unit8/unit8_part2.ipynb
@@ -251,7 +251,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install sample-factory==2.0.2"
+        "!pip install sample-factory==2.1.1"
       ],
       "metadata": {
         "id": "alxUt7Au-O8e"


### PR DESCRIPTION
To fix error with dependencies which I got from Colab, I think `sample-factory` could be safely updated to `2.1.1`

Error which I get:
```
Collecting sample-factory==2.0.2
  Downloading sample_factory-2.0.2-py3-none-any.whl.metadata (11 kB)
WARNING: Ignoring version 2.0.2 of sample-factory since it has invalid metadata:
Requested sample-factory==2.0.2 from https://files.pythonhosted.org/packages/cd/f9/b64b51f290fb6ab349e51684686865c100de74d1b42f8b39680fcc5f27b6/sample_factory-2.0.2-py3-none-any.whl has invalid metadata: Expected matching RIGHT_PARENTHESIS for LEFT_PARENTHESIS, after version specifier
    numpy (>=1.18.1<2.0)
          ~~~~~~~~~^
Please use pip<24.1 if you need to use this version.
ERROR: Could not find a version that satisfies the requirement sample-factory==2.0.2 (from versions: 1.0.5, 1.0.6, 1.0.117, 1.117.1, 1.117.2, 1.117.3, 1.120.0, 1.120.1, 1.120.2, 1.121.0, 1.121.1, 1.121.2, 1.121.3, 1.121.4, 1.123.0, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.1.1)
ERROR: No matching distribution found for sample-factory==2.0.2
```
After upgrading to `2.1.1` notebook runs just fine.