### PR TITLE
Updated requirements and changed pickle import

### DIFF
--- a/notebooks/unit2/requirements-unit2.txt
+++ b/notebooks/unit2/requirements-unit2.txt
@@ -3,7 +3,6 @@ pygame
 numpy
 
 huggingface_hub
-pickle5
 pyyaml==6.0
 imageio
 imageio_ffmpeg

--- a/notebooks/unit2/unit2.ipynb
+++ b/notebooks/unit2/unit2.ipynb
@@ -289,7 +289,7 @@
         "import os\n",
         "import tqdm\n",
         "\n",
-        "import pickle5 as pickle\n",
+        "import pickle\n",
         "from tqdm.notebook import tqdm"
       ]
     },


### PR DESCRIPTION
pickle5 is compatible only with Python 3.8 and earlier. If you're using Python 3.9 or later, you don't need pickle5 because its functionality is already included in the standard library.

Resolves #584 