### PR TITLE
Add puppo-the-corgi archive.org mirror for missing Unity blog post

### DIFF
--- a/units/en/unitbonus1/how-huggy-works.mdx
+++ b/units/en/unitbonus1/how-huggy-works.mdx
@@ -1,6 +1,6 @@
 # How Huggy works [[how-huggy-works]]
 
-Huggy is a Deep Reinforcement Learning environment made by Hugging Face and based on [Puppo the Corgi, a project by the Unity MLAgents team](https://blog.unity.com/technology/puppo-the-corgi-cuteness-overload-with-the-unity-ml-agents-toolkit).
+Huggy is a Deep Reinforcement Learning environment made by Hugging Face and based on [Puppo the Corgi, a project by the Unity MLAgents team](https://blog.unity.com/technology/puppo-the-corgi-cuteness-overload-with-the-unity-ml-agents-toolkit) ([mirror](https://web.archive.org/web/20200413132335/https://blogs.unity3d.com/2018/10/02/puppo-the-corgi-cuteness-overload-with-the-unity-ml-agents-toolkit/)).
 This environment was created using the [Unity game engine](https://unity.com/) and [MLAgents](https://github.com/Unity-Technologies/ml-agents). ML-Agents is a toolkit for the game engine from Unity that allows us to **create environments using Unity or use pre-made environments to train our agents**.
 
 <img src="https://huggingface.co/datasets/huggingface-deep-rl-course/course-images/resolve/main/en/notebooks/unit-bonus1/huggy.jpg" alt="Huggy" width="100%">


### PR DESCRIPTION
The original link 404's. I've added a link to archive.org's capture. The videos work too.