### PR TITLE
Replace pickle5 with standard pickle for Python 3.11+ compatibility

### DIFF
--- a/notebooks/unit2/requirements-unit2.txt
+++ b/notebooks/unit2/requirements-unit2.txt
@@ -3,7 +3,6 @@ pygame
 numpy
 
 huggingface_hub
-pickle5
 pyyaml==6.0
 imageio
 imageio_ffmpeg

--- a/notebooks/unit2/unit2.ipynb
+++ b/notebooks/unit2/unit2.ipynb
@@ -289,7 +289,7 @@
         "import os\n",
         "import tqdm\n",
         "\n",
-        "import pickle5 as pickle\n",
+        "import pickle\n",
         "from tqdm.notebook import tqdm"
       ]
     },


### PR DESCRIPTION
This PR replaces pickle5 with the standard pickle library since:
1. Python 3.11+ doesn't support pickle5 (causing compatibility issues)
2. The standard library's pickle now includes equivalent functionality
3. Maintains backward compatibility while fixing the conflict
4. Tested with Python 3.11/3.12 - resolves the import error while preserving existing functionality.