### PR TITLE
Update sample-factory version to 2.1.3 to no pytorch 2.6+ error occurs

### DIFF
--- a/notebooks/unit8/unit8_part2.ipynb
+++ b/notebooks/unit8/unit8_part2.ipynb
@@ -251,7 +251,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install sample-factory==2.1.1"
+        "!pip install sample-factory==2.1.3"
       ],
       "metadata": {
         "id": "alxUt7Au-O8e"


### PR DESCRIPTION
Sample-factory has an updated version which allows it to work with Pytroch2.6+
