### PR TITLE
Add conditional import for pickle5 in unit-2 hands-on

### DIFF
--- a/notebooks/unit2/requirements-unit2.txt
+++ b/notebooks/unit2/requirements-unit2.txt
@@ -3,7 +3,7 @@ pygame
 numpy
 
 huggingface_hub
-pickle5
+pickle5; python_version < "3.8"
 pyyaml==6.0
 imageio
 imageio_ffmpeg

--- a/units/en/unit2/hands-on.mdx
+++ b/units/en/unit2/hands-on.mdx
@@ -182,7 +182,10 @@ import imageio
 import os
 import tqdm
 
-import pickle5 as pickle
+try:
+    import pickle5 as pickle
+except ImportError:
+    import pickle
 from tqdm.notebook import tqdm
 ```
 


### PR DESCRIPTION
This PR resolves installation failures when setting up the Unit 2 hands-on exercise requirements. The current `pickle5` dependency causes build errors on Python 3.8+, since the package is no longer required for modern Python versions and Google Colab already runs Python 3.10+.

Yet, in case a student decides to do the hands-on exercise locally instead of doing it in Colab and happens to have a Python version older than 3.8, the code works just as fine.

**Approach:**
- Uses conditional requirement: `pickle5; python_version < "3.8"`
- Implements graceful fallback import pattern
- Maintains compatibility with all Python versions"

**Testing:**
- [x] Verified installation works on Python 3.10+ (Colab environment)
- [x] Confirmed backward compatibility approach