### PR TITLE
Fix np.bool8 error for NumPy 1.24+ compatibility

### DIFF
--- a/notebooks/unit4/unit4.ipynb
+++ b/notebooks/unit4/unit4.ipynb
@@ -276,6 +276,8 @@
       "outputs": [],
       "source": [
         "import numpy as np\n",
+  	"if not hasattr(np, 'bool8'):\n",
+  	"    np.bool8 = np.bool_\n",
         "\n",
         "from collections import deque\n",
         "\n",


### PR DESCRIPTION
# Fix: Add compatibility patch for deprecated `np.bool8` in NumPy ≥1.24

## Summary

This PR addresses a compatibility issue with newer versions of NumPy (1.24+) by defining `np.bool8` as an alias to `np.bool_` when it is missing. This fixes runtime errors in environments that still reference `np.bool8`.

## Problem

When using NumPy ≥1.24, the following error is raised:

```
AttributeError: module 'numpy' has no attribute 'bool8'
```

This is because of the removal of the `np.bool8` alias, which some environments or wrappers (e.g., from `gym-games` or older Gym integrations) still use.

## Solution

This PR adds the following patch at runtime:

```python
import numpy as np

if not hasattr(np, 'bool8'):
    np.bool8 = np.bool_
```

## References

- [NumPy 1.24 Release Notes – Expired Deprecations](https://numpy.org/devdocs/release/1.24.0-notes.html#expired-deprecations)

