### PR TITLE
Update requirements-unit1.txt (workaround to Box2D installation failure)

### DIFF
--- a/notebooks/unit1/requirements-unit1.txt
+++ b/notebooks/unit1/requirements-unit1.txt
@@ -1,4 +1,5 @@
 stable-baselines3==2.0.0a5
 swig
-gymnasium[box2d]
+gymnasium
+box2d-py
 huggingface_sb3


### PR DESCRIPTION
I saw reports on [the forum](https://discuss.huggingface.co/t/rl-course-unit-1-python-setup-py-egg-info-did-not-run-successfully/167429/3) and Discord.
This is a workaround to bypass [the upstream Box2D installation failure](https://github.com/Farama-Foundation/Gymnasium/issues/1324).