### PR TITLE
Fix gymnasium[box2d] install failure on Colab

### DIFF
--- a/notebooks/unit1/requirements-unit1.txt
+++ b/notebooks/unit1/requirements-unit1.txt
@@ -1,4 +1,5 @@
 stable-baselines3==2.0.0a5
 swig
-gymnasium[box2d]
+gymnasium[box2d]==0.29.1
+pygame==2.5.2
 huggingface_sb3


### PR DESCRIPTION

Fix gymnasium[box2d] install failure on Colab by pinning compatible versions

- Pinned gymnasium[box2d] to 0.29.1 to avoid pulling pygame==2.1.3 (which fails to build on Colab)
- Added explicit pygame==2.5.2 as a known working version
- No functional changes to other dependencies