### PR TITLE
Update pyyaml version constraint to >=6.0.1

### DIFF
--- a/notebooks/unit2/requirements-unit2.txt
+++ b/notebooks/unit2/requirements-unit2.txt
@@ -4,7 +4,7 @@ numpy
 
 huggingface_hub
 pickle5
-pyyaml==6.0
+pyyaml>=6.0.1
 imageio
 imageio_ffmpeg
 pyglet==1.5.1


### PR DESCRIPTION
The pyyaml 6.0 is incompatible with newer versions of Cython (3.0+). pyyaml==6.0.1 (or newer) includes a fix that forces the use of a compatible Cython version.