### PR TITLE
docs(unit7): fix 'how can can' typo in multi-agent setting intro

### DIFF
--- a/units/en/unit7/multi-agent-setting.mdx
+++ b/units/en/unit7/multi-agent-setting.mdx
@@ -5,7 +5,7 @@ For this section, you're going to watch this excellent introduction to multi-age
 <Youtube id="qgb0gyrpiGk" />
 
 
-In this video, Brian talked about how to design multi-agent systems. He specifically took a multi-agents system of vacuum cleaners and asked: **how can can cooperate with each other**?
+In this video, Brian talked about how to design multi-agent systems. He specifically took a multi-agent system of vacuum cleaners and asked: **how can they cooperate with each other**?
 
 We have two solutions to design this multi-agent reinforcement learning system (MARL).
 


### PR DESCRIPTION
Closes #675.

`units/en/unit7/multi-agent-setting.mdx:8` had two small issues in the paragraph describing Brian Douglas's vacuum cleaner example:

- `multi-agents system` → `multi-agent system` (singular adjective)
- `how **can can** cooperate with each other` → `how **can they** cooperate with each other` (dropped subject)

Fix per the suggestion in #675.