### PR TITLE
Remove duplicate refresh instruction in hands-on.mdx

### DIFF
--- a/units/en/unit4/hands-on.mdx
+++ b/units/en/unit4/hands-on.mdx
@@ -26,8 +26,6 @@ To validate this hands-on for the certification process, you need to push your t
 
 To find your result, go to the leaderboard and find your model, **the result = mean_reward - std of reward**. **If you don't see your model on the leaderboard, go at the bottom of the leaderboard page and click on the refresh button**.
 
-**If you don't find your model, go to the bottom of the page and click on the refresh button.**
-
 For more information about the certification process, check this section 👉 https://huggingface.co/deep-rl-course/en/unit0/introduction#certification-process
 
 And you can check your progress here 👉 https://huggingface.co/spaces/ThomasSimonini/Check-my-progress-Deep-RL-Course


### PR DESCRIPTION
Removed a duplicated instruction about refreshing the leaderboard when the model is not found.

This improves the documentation clarity and avoids repeating the same guidance twice.