### PR TITLE
Fix broken Gymnasium migration guide link in Unit 4

### DIFF
--- a/notebooks/unit4/unit4.ipynb
+++ b/notebooks/unit4/unit4.ipynb
@@ -235,7 +235,7 @@
         "- In `gym` we don't have `terminated` and `truncated` but only `done`.\n",
         "- In `gym` using `env.step()` returns `state, reward, done, info`\n",
         "\n",
-        "You can learn more about the differences between Gym and Gymnasium here 👉 https://gymnasium.farama.org/content/migration-guide/\n",
+        "You can learn more about the differences between Gym and Gymnasium here 👉 https://gymnasium.farama.org/introduction/migration_guide/\n",
         "\n",
         "\n",
         "You can see here all the Reinforce models available 👉 https://huggingface.co/models?other=reinforce\n",


### PR DESCRIPTION
Updated the outdated Gymnasium migration guide link in Unit 4.

The previous link returned a 404 error:
https://gymnasium.farama.org/content/migration-guide/

Updated it to the current migration guide:
https://gymnasium.farama.org/introduction/migration_guide/